### PR TITLE
Start indicator in systemd when ayatana-indicators.target is started

### DIFF
--- a/data/ayatana-indicator-power.service.in
+++ b/data/ayatana-indicator-power.service.in
@@ -1,8 +1,11 @@
 [Unit]
 Description=Ayatana Indicator Power
 PartOf=graphical-session.target
-After=ayatana-indicators-pre.target
+PartOf=ayatana-indicators.target
 
 [Service]
 ExecStart=@pkglibexecdir@/ayatana-indicator-power-service
 Restart=on-failure
+
+[Install]
+WantedBy=ayatana-indicators.target

--- a/debian/ayatana-indicator-power.links
+++ b/debian/ayatana-indicator-power.links
@@ -1,0 +1,2 @@
+# Because dh-systemd does not yet support user units, we manually make the WantedBy link
+/usr/lib/systemd/user/ayatana-indicator-power.service /usr/lib/systemd/user/ayatana-indicators.target.wants/ayatana-indicator-power.service

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
 %:
-	dh $@
+	dh $@ --with systemd
 
 override_dh_install:
 	find debian/ayatana-indicator-power -name \*.la -delete


### PR DESCRIPTION
This starts the indicator with the ayatana-indicators.target

Patch from:
https://bazaar.launchpad.net/~mterry/indicator-power/systemd-lifecycle/revision/311

Depends on https://github.com/AyatanaIndicators/libayatana-indicator/pull/7