### PR TITLE
Do not call the power settings handler if the command is unknown

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -134,7 +134,10 @@ utils_handle_settings_request (void)
        }
     }
 
-  execute_command (control_center_cmd);
+    if (control_center_cmd)
+    {
+        execute_command(control_center_cmd);
+    }
 }
 
 gboolean


### PR DESCRIPTION
fixes #12 