### PR TITLE
Theming fix: Separate panel icons from the power menu icons

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -3,7 +3,7 @@
 A simple Device structure used internally by indicator-power
 
 Copyright 2012 Canonical Ltd.
-Copyright 2021 Robert Tari
+Copyright 2021-2022 Robert Tari
 
 Authors:
     Charles Kerr <charles.kerr@canonical.com>
@@ -395,6 +395,7 @@ device_kind_to_string (UpDeviceKind kind)
 /**
   indicator_power_device_get_icon_names:
   @device: #IndicatorPowerDevice from which to generate the icon names
+  @panel: Whether to prefer panel icons
 
   See also indicator_power_device_get_gicon().
 
@@ -403,7 +404,7 @@ device_kind_to_string (UpDeviceKind kind)
   Free with g_strfreev() when done.
 */
 GStrv
-indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
+indicator_power_device_get_icon_names (const IndicatorPowerDevice * device, gboolean panel)
 {
   const gchar *suffix_str;
   const gchar *index_str;
@@ -422,26 +423,43 @@ indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
 
   if (kind == UP_DEVICE_KIND_LINE_POWER)
     {
-      g_ptr_array_add (names, g_strdup("ac-adapter-symbolic"));
+      if (panel)
+      {
+        g_ptr_array_add (names, g_strdup("ac-adapter-panel"));
+      }
+
       g_ptr_array_add (names, g_strdup("ac-adapter"));
     }
   else if (kind == UP_DEVICE_KIND_MONITOR)
     {
-      g_ptr_array_add (names, g_strdup("gpm-monitor-symbolic"));
+      if (panel)
+      {
+        g_ptr_array_add (names, g_strdup("gpm-monitor-panel"));
+      }
+
       g_ptr_array_add (names, g_strdup("gpm-monitor"));
     }
   else switch (state)
     {
       case UP_DEVICE_STATE_EMPTY:
-        g_ptr_array_add (names, g_strdup_printf("%s-empty-symbolic", kind_str));
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf("%s-empty-panel", kind_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf("gpm-%s-empty", kind_str));
         g_ptr_array_add (names, g_strdup_printf("gpm-%s-000", kind_str));
         g_ptr_array_add (names, g_strdup_printf("%s-empty", kind_str));
         break;
 
       case UP_DEVICE_STATE_FULLY_CHARGED:
-        g_ptr_array_add (names, g_strdup_printf("%s-full-charged-symbolic", kind_str));
-        g_ptr_array_add (names, g_strdup_printf("%s-full-charging-symbolic", kind_str));
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf("%s-full-charged-panel", kind_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf("gpm-%s-full", kind_str));
         g_ptr_array_add (names, g_strdup_printf("gpm-%s-100", kind_str));
         g_ptr_array_add (names, g_strdup_printf("%s-full-charged", kind_str));
@@ -452,15 +470,31 @@ indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
 
         suffix_str = get_device_icon_suffix (percentage);
         index_str = get_closest_10_percent_percentage (percentage);
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging-panel", kind_str, index_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging", kind_str, index_str));
         g_ptr_array_add (names, g_strdup_printf ("gpm-%s-%s-charging", kind_str, index_str));
         index_str_2 = get_fallback_device_icon_index (percentage);
         if (g_strcmp0 (index_str, index_str_2))
           {
+            if (panel)
+            {
+              g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging-panel", kind_str, index_str_2));
+            }
+
             g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging", kind_str, index_str_2));
             g_ptr_array_add (names, g_strdup_printf ("gpm-%s-%s-charging", kind_str, index_str_2));
           }
-        g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging-symbolic", kind_str, suffix_str));
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging-panel", kind_str, suffix_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf ("%s-%s-charging", kind_str, suffix_str));
         // NB: fallthrough to use foo-bar as a fallback for foo-bar-charging
 
@@ -470,20 +504,41 @@ indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
       case UP_DEVICE_STATE_UNKNOWN: /* http://pad.lv/1470080 */
         suffix_str = get_device_icon_suffix (percentage);
         index_str = get_closest_10_percent_percentage (percentage);
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf ("%s-%s-panel", kind_str, index_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf ("%s-%s", kind_str, index_str));
         g_ptr_array_add (names, g_strdup_printf ("gpm-%s-%s", kind_str, index_str));
         index_str_2 = get_fallback_device_icon_index (percentage);
         if (g_strcmp0 (index_str, index_str_2))
           {
+            if (panel)
+            {
+              g_ptr_array_add (names, g_strdup_printf ("%s-%s-panel", kind_str, index_str_2));
+            }
+
             g_ptr_array_add (names, g_strdup_printf ("%s-%s", kind_str, index_str_2));
             g_ptr_array_add (names, g_strdup_printf ("gpm-%s-%s", kind_str, index_str_2));
           }
-        g_ptr_array_add (names, g_strdup_printf ("%s-%s-symbolic", kind_str, suffix_str));
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf ("%s-%s-panel", kind_str, suffix_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf ("%s-%s", kind_str, suffix_str));
         break;
 
       default:
-        g_ptr_array_add (names, g_strdup_printf("%s-missing-symbolic", kind_str));
+
+        if (panel)
+        {
+          g_ptr_array_add (names, g_strdup_printf("%s-missing-panel", kind_str));
+        }
+
         g_ptr_array_add (names, g_strdup_printf("gpm-%s-missing", kind_str));
         g_ptr_array_add (names, g_strdup_printf("%s-missing", kind_str));
     }
@@ -495,6 +550,7 @@ indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
 /**
   indicator_power_device_get_gicon:
   @device: #IndicatorPowerDevice to generate the icon names from
+  @panel: Whether to prefer panel icons
 
   A convenience function to call g_themed_icon_new_from_names()
   with the names returned by indicator_power_device_get_icon_names()
@@ -502,9 +558,9 @@ indicator_power_device_get_icon_names (const IndicatorPowerDevice * device)
   Return value: (transfer full): A themed GIcon
 */
 GIcon *
-indicator_power_device_get_gicon (const IndicatorPowerDevice * device)
+indicator_power_device_get_gicon (const IndicatorPowerDevice * device, gboolean panel)
 {
-  GStrv names = indicator_power_device_get_icon_names (device);
+  GStrv names = indicator_power_device_get_icon_names (device, panel);
   GIcon * icon = g_themed_icon_new_from_names (names, -1);
   g_strfreev (names);
   return icon;

--- a/src/device.h
+++ b/src/device.h
@@ -3,9 +3,11 @@
 A simple Device structure used internally by indicator-power
 
 Copyright 2012 Canonical Ltd.
+Copyright 2022 Robert Tari
 
 Authors:
     Charles Kerr <charles.kerr@canonical.com>
+    Robert Tari <robert@tari.in>
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -126,8 +128,8 @@ gdouble       indicator_power_device_get_percentage        (const IndicatorPower
 time_t        indicator_power_device_get_time              (const IndicatorPowerDevice * device);
 gboolean      indicator_power_device_get_power_supply      (const IndicatorPowerDevice * device);
 
-GStrv         indicator_power_device_get_icon_names        (const IndicatorPowerDevice * device);
-GIcon       * indicator_power_device_get_gicon             (const IndicatorPowerDevice * device);
+GStrv         indicator_power_device_get_icon_names        (const IndicatorPowerDevice * device, gboolean panel);
+GIcon       * indicator_power_device_get_gicon             (const IndicatorPowerDevice * device, gboolean panel);
 
 
 char        * indicator_power_device_get_readable_text     (const IndicatorPowerDevice * device);

--- a/src/notifier.c
+++ b/src/notifier.c
@@ -302,7 +302,7 @@ notification_show(IndicatorPowerNotifier * self)
         : _("Battery Critical");
   pct = indicator_power_device_get_percentage(p->battery);
   body = g_strdup_printf(_("%.0f%% charge remaining"), pct);
-  icon_names = indicator_power_device_get_icon_names(p->battery);
+  icon_names = indicator_power_device_get_icon_names(p->battery, FALSE);
   if (icon_names && *icon_names)
     icon_name = icon_names[0];
   else

--- a/src/service.c
+++ b/src/service.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013-2016 Canonical Ltd.
- * Copyright 2021 Robert Tari
+ * Copyright 2021-2022 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -489,7 +489,7 @@ create_header_state (IndicatorPowerService * self)
             g_free (title);
         }
 
-      if ((icon = indicator_power_device_get_gicon (p->primary_device)))
+      if ((icon = indicator_power_device_get_gicon (p->primary_device, TRUE)))
         {
           GVariant * serialized_icon = g_icon_serialize (icon);
 
@@ -530,7 +530,7 @@ append_device_to_menu (GMenu * menu, const IndicatorPowerDevice * device, int pr
 
     g_menu_item_set_attribute (item, "x-ayatana-type", "s", "org.ayatana.indicator.basic");
 
-    if ((icon = indicator_power_device_get_gicon (device)))
+    if ((icon = indicator_power_device_get_gicon (device, FALSE)))
       {
         GVariant * serialized_icon = g_icon_serialize (icon);
 

--- a/tests/test-device.cc
+++ b/tests/test-device.cc
@@ -71,7 +71,7 @@ class DeviceTest : public ::testing::Test
     static std::string get_icon_names_from_device(const IndicatorPowerDevice* device)
     {
       std::string ret;
-      char ** names = indicator_power_device_get_icon_names (device);
+      char ** names = indicator_power_device_get_icon_names (device, TRUE);
       char * str = g_strjoinv (";", names);
       if (str != nullptr)
         ret = str;
@@ -282,7 +282,7 @@ TEST_F(DeviceTest, IconNames)
 
   // bad arguments
   log_count_ipower_expected++;
-  ASSERT_TRUE (indicator_power_device_get_icon_names (NULL) == NULL);
+  ASSERT_TRUE (indicator_power_device_get_icon_names (NULL, TRUE) == NULL);
 
   // power
   g_object_set (o, INDICATOR_POWER_DEVICE_KIND, UP_DEVICE_KIND_LINE_POWER,


### PR DESCRIPTION
This fixes the broken theming issue where the Power Indicator menu shows the same icons as used by the panel, rather than the ones used elsewhere on the system.

End result: makes any theme capable of becoming Ayatana-friendly without hacks.