### PR TITLE
Revert "Don't prioritize discharging items with no time estimate that…

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -200,14 +200,6 @@ device_compare_func (gconstpointer ga, gconstpointer gb)
     }
 
   state = UP_DEVICE_STATE_DISCHARGING;
-
-  /* discharging items with more than 10% remaining always lose */
-  if (!ret && (((a_state == state) && !a_time && (a_percentage > 10))))
-      ret = 1;
-
-  if (!ret && (((b_state == state) && !b_time && (b_percentage > 10))))
-      ret = -1;
-
   if (!ret && (((a_state == state) && a_time) ||
                ((b_state == state) && b_time)))
     {


### PR DESCRIPTION
… have more than 10% power remaining."

As the battery in the Pixel 3a running 20.04 exposes itself without any time estimates, it gets hidden by the indicator unless below 10% of charge.

The original commit message mentions low-power devices having no time estimates most probably due to lasting long, but (without an honest checkup of the upstream kernel sources) I doubt the kernel driver to distinguish between those capabilities in the power_supply properties, hence remove this artificial limit again.

This reverts commit 522fdc6abbfee52dec5c6b0194cf87ffcc0f3dcd.