### PR TITLE
src/service.c: also update devices section on phone profile

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -726,6 +726,7 @@ rebuild_now (IndicatorPowerService * self, guint sections)
 
   if (sections & SECTION_DEVICES)
     {
+      rebuild_section (phone->submenu, 0, create_devices_section (self, PROFILE_PHONE));
       rebuild_section (desktop->submenu, 0, create_devices_section (self, PROFILE_DESKTOP));
       rebuild_section (greeter->submenu, 0, create_devices_section (self, PROFILE_DESKTOP_GREETER));
     }


### PR DESCRIPTION
Since there's no longer an action to update the battery level, now the submenu itself has to also be updated on the phone.

Bug-UBports: https://gitlab.com/ubports/development/core/lomiri/-/issues/70