### PR TITLE
{CMakeLists.txt,src/service.c}: Make building against librda optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(ENABLE_COVERAGE "Enable coverage reports (includes enabling all tests and
 option(ENABLE_WERROR "Treat all build warnings as errors" OFF)
 option(ENABLE_LOMIRI_FEATURES "Build with Lomiri-specific libraries, schemas and media" OFF)
 option(ENABLE_DEVICEINFO "Build with deviceinfo integration" OFF)
+option(ENABLE_RDA "Build with RDA (remote desktop awareness) support" ON)
 
 if(ENABLE_COVERAGE)
     set(ENABLE_TESTS ON)
@@ -73,7 +74,6 @@ set(
     gio-unix-2.0>=2.36
     libnotify>=0.7.6
     libayatana-common>=0.9.1
-    rda
 )
 
 if (ENABLE_LOMIRI_FEATURES)
@@ -87,6 +87,17 @@ if (ENABLE_LOMIRI_FEATURES)
     add_definitions (
         -DLOMIRI_FEATURES_ENABLED
         -DLOMIRI_SOUNDSDIR="${LOMIRI_SOUNDSDIR}"
+    )
+endif ()
+
+if (ENABLE_RDA)
+    list (
+        APPEND
+        SERVICE_DEPS
+        rda
+    )
+    add_definitions (
+      -DRDA_ENABLED
     )
 endif ()
 

--- a/src/service.c
+++ b/src/service.c
@@ -22,7 +22,9 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include <rda/rda.h>
+#ifdef RDA_ENABLED
+#  include <rda/rda.h>
+#endif /* RDA_ENABLED */
 #include <ayatana/common/utils.h>
 #include "brightness.h"
 #include "dbus-shared.h"
@@ -1189,11 +1191,14 @@ indicator_power_service_init (IndicatorPowerService * self)
 
   p->cancellable = g_cancellable_new ();
 
+#ifdef RDA_ENABLED
   if (!ayatana_common_utils_is_lomiri())
   {
       p->bLocal = rda_session_is_local ();
   }
-  else {
+  else
+#endif /* RDA_ENABLED */
+  {
       p->bLocal = TRUE;
   }
   p->settings = g_settings_new ("org.ayatana.indicator.power");


### PR DESCRIPTION
@tari01: Ideally, this should be reviewed until Monday, as well, targetting a 23.10.1 release. If you have any changes for the power indicator till then, I'll be happy to include those.