### PR TITLE
Revert "Remove orphan osd-notify remnants"

### DIFF
--- a/src/notifier.c
+++ b/src/notifier.c
@@ -379,6 +379,7 @@ notification_show(IndicatorPowerNotifier * self)
         }
       #ifdef LOMIRI_FEATURES_ENABLED
       if (are_lomiri_snap_decisions_supported(self)) {
+        /* Yes, all supposedly boolean values take strings... */
         notify_notification_set_hint(nn, "x-lomiri-snap-decisions", g_variant_new_string("true"));
         notify_notification_set_hint(nn, "x-lomiri-non-shaped-icon", g_variant_new_string("true"));
         notify_notification_set_hint(nn, "x-lomiri-private-affirmative-tint", g_variant_new_string("true"));

--- a/src/notifier.c
+++ b/src/notifier.c
@@ -343,6 +343,10 @@ notification_show(IndicatorPowerNotifier * self)
             }
         }
 
+      notify_notification_set_hint(nn, "x-lomiri-snap-decisions", g_variant_new_string("true"));
+      notify_notification_set_hint(nn, "x-lomiri-non-shaped-icon", g_variant_new_string("true"));
+      notify_notification_set_hint(nn, "x-lomiri-private-affirmative-tint", g_variant_new_string("true"));
+      notify_notification_set_hint(nn, "x-lomiri-snap-decisions-timeout", g_variant_new_int32(INT32_MAX));
       notify_notification_set_timeout(nn, NOTIFY_EXPIRES_NEVER);
       notify_notification_add_action(nn, "dismiss", _("OK"), on_dismiss_clicked, NULL, NULL);
       notify_notification_add_action(nn, "settings", _("Battery settings"), on_battery_settings_clicked, NULL, NULL);

--- a/tests/test-notify.cc
+++ b/tests/test-notify.cc
@@ -72,6 +72,8 @@ protected:
   static constexpr char const * METHOD_GET_INFO {"GetServerInformation"};
   static constexpr char const * SIGNAL_CLOSED {"NotificationClosed"};
 
+  static constexpr char const * HINT_TIMEOUT {"x-lomiri-snap-decisions-timeout"};
+
 protected:
 
   void SetUp()

--- a/tests/test-notify.cc
+++ b/tests/test-notify.cc
@@ -72,8 +72,6 @@ protected:
   static constexpr char const * METHOD_GET_INFO {"GetServerInformation"};
   static constexpr char const * SIGNAL_CLOSED {"NotificationClosed"};
 
-  static constexpr char const * HINT_TIMEOUT {"x-lomiri-snap-decisions-timeout"};
-
 protected:
 
   void SetUp()


### PR DESCRIPTION
As discussed in [1], these hints are essential to make the indicator functions correctly on Lomiri. These hints should not make any difference on DE's that doesn't support them.

After reverting, remove an unused variable in a test.

[1] https://gitlab.com/ubports/development/core/content-hub/-/merge_requests/32#note_1552217874