### PR TITLE
Add a power-saver section to the phone menu driven by repowerd's PowerSaver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SERVICE_MANUAL_SOURCES
     keep-screen-on.c
     flashlight.c
     notifier.c
+    power-saver.c
     testing.c
     service.c
     utils.c)

--- a/src/power-saver.c
+++ b/src/power-saver.c
@@ -1,0 +1,358 @@
+/*
+ * Copyright © 2026 UBports Foundation.
+ * Copyright © 2026 Volla Systeme GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ */
+
+#include "power-saver.h"
+
+#include <gio/gio.h>
+
+#define BUS_NAME       "com.lomiri.Repowerd.PowerSaver"
+#define OBJECT_PATH    "/com/lomiri/Repowerd/PowerSaver"
+#define IFACE          "com.lomiri.Repowerd.PowerSaver"
+
+struct _IndicatorPowerSaverPriv
+{
+  GDBusProxy   * proxy;
+  GCancellable * cancellable;
+
+  guint    watch_id;
+  gboolean service_available;
+  gboolean available;
+  gchar  * device_name;
+  GStrv    profiles;
+  gchar  * active_profile;
+  gboolean auto_on_battery;
+};
+
+enum
+{
+  SIGNAL_CHANGED,
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0 };
+
+/* G_DEFINE_TYPE_WITH_PRIVATE() expands to <TypeName>Private. */
+typedef struct _IndicatorPowerSaverPriv IndicatorPowerSaverPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(IndicatorPowerSaver, indicator_power_saver, G_TYPE_OBJECT)
+
+static void emit_changed(IndicatorPowerSaver * self)
+{
+  g_signal_emit(self, signals[SIGNAL_CHANGED], 0);
+}
+
+static gboolean strv_equal(GStrv a, GStrv b)
+{
+  guint la = a ? g_strv_length(a) : 0;
+  guint lb = b ? g_strv_length(b) : 0;
+  if (la != lb) return FALSE;
+  for (guint i = 0; i < la; ++i)
+    if (g_strcmp0(a[i], b[i]) != 0) return FALSE;
+  return TRUE;
+}
+
+static void refresh_available_done(GObject * source, GAsyncResult * res, gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GVariant * v = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &err);
+  if (!v) { g_clear_error(&err); g_object_unref(self); return; }
+  gboolean a = FALSE;
+  g_variant_get(v, "(b)", &a);
+  if (a != self->priv->available)
+    { self->priv->available = a; emit_changed(self); }
+  g_variant_unref(v);
+  g_object_unref(self);
+}
+
+static void refresh_device_done(GObject * source, GAsyncResult * res, gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GVariant * v = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &err);
+  if (!v) { g_clear_error(&err); g_object_unref(self); return; }
+  const gchar * s = NULL;
+  g_variant_get(v, "(&s)", &s);
+  if (g_strcmp0(s, self->priv->device_name) != 0)
+    {
+      g_free(self->priv->device_name);
+      self->priv->device_name = g_strdup(s ? s : "");
+      emit_changed(self);
+    }
+  g_variant_unref(v);
+  g_object_unref(self);
+}
+
+static void refresh_profiles_done(GObject * source, GAsyncResult * res, gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GVariant * v = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &err);
+  if (!v) { g_clear_error(&err); g_object_unref(self); return; }
+
+  GVariant * inner = g_variant_get_child_value(v, 0);
+  GVariantIter it;
+  g_variant_iter_init(&it, inner);
+  GPtrArray * arr = g_ptr_array_new();
+  gchar * s;
+  while (g_variant_iter_next(&it, "&s", &s))
+    g_ptr_array_add(arr, g_strdup(s));
+  g_ptr_array_add(arr, NULL);
+  GStrv next = (GStrv) g_ptr_array_free(arr, FALSE);
+
+  if (!strv_equal(self->priv->profiles, next))
+    {
+      g_strfreev(self->priv->profiles);
+      self->priv->profiles = next;
+      emit_changed(self);
+    }
+  else
+    {
+      g_strfreev(next);
+    }
+  g_variant_unref(inner);
+  g_variant_unref(v);
+  g_object_unref(self);
+}
+
+static void refresh_active_done(GObject * source, GAsyncResult * res, gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GVariant * v = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &err);
+  if (!v) { g_clear_error(&err); g_object_unref(self); return; }
+  const gchar * s = NULL;
+  g_variant_get(v, "(&s)", &s);
+  if (g_strcmp0(s, self->priv->active_profile) != 0)
+    {
+      g_free(self->priv->active_profile);
+      self->priv->active_profile = g_strdup(s ? s : "");
+      emit_changed(self);
+    }
+  g_variant_unref(v);
+  g_object_unref(self);
+}
+
+static void refresh_auto_done(GObject * source, GAsyncResult * res, gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GVariant * v = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &err);
+  if (!v) { g_clear_error(&err); g_object_unref(self); return; }
+  gboolean b = FALSE;
+  g_variant_get(v, "(b)", &b);
+  if (b != self->priv->auto_on_battery)
+    { self->priv->auto_on_battery = b; emit_changed(self); }
+  g_variant_unref(v);
+  g_object_unref(self);
+}
+
+static void refresh_all(IndicatorPowerSaver * self)
+{
+  if (!self->priv->proxy) return;
+  g_dbus_proxy_call(self->priv->proxy, "IsAvailable", NULL,
+                    G_DBUS_CALL_FLAGS_NONE, -1, self->priv->cancellable,
+                    refresh_available_done, g_object_ref(self));
+  g_dbus_proxy_call(self->priv->proxy, "GetDeviceName", NULL,
+                    G_DBUS_CALL_FLAGS_NONE, -1, self->priv->cancellable,
+                    refresh_device_done, g_object_ref(self));
+  g_dbus_proxy_call(self->priv->proxy, "ListProfiles", NULL,
+                    G_DBUS_CALL_FLAGS_NONE, -1, self->priv->cancellable,
+                    refresh_profiles_done, g_object_ref(self));
+  g_dbus_proxy_call(self->priv->proxy, "GetActiveProfile", NULL,
+                    G_DBUS_CALL_FLAGS_NONE, -1, self->priv->cancellable,
+                    refresh_active_done, g_object_ref(self));
+  g_dbus_proxy_call(self->priv->proxy, "GetAutoOnBattery", NULL,
+                    G_DBUS_CALL_FLAGS_NONE, -1, self->priv->cancellable,
+                    refresh_auto_done, g_object_ref(self));
+}
+
+static void on_proxy_signal(GDBusProxy * proxy G_GNUC_UNUSED,
+                            const gchar * sender G_GNUC_UNUSED,
+                            const gchar * name,
+                            GVariant * params,
+                            gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  if (g_strcmp0(name, "ActiveProfileChanged") == 0)
+    {
+      const gchar * s = NULL;
+      g_variant_get(params, "(&s)", &s);
+      if (g_strcmp0(s, self->priv->active_profile) != 0)
+        {
+          g_free(self->priv->active_profile);
+          self->priv->active_profile = g_strdup(s ? s : "");
+          emit_changed(self);
+        }
+    }
+  else if (g_strcmp0(name, "AutoOnBatteryChanged") == 0)
+    {
+      gboolean b = FALSE;
+      g_variant_get(params, "(b)", &b);
+      if (b != self->priv->auto_on_battery)
+        { self->priv->auto_on_battery = b; emit_changed(self); }
+    }
+}
+
+static void on_proxy_ready(GObject * source G_GNUC_UNUSED,
+                           GAsyncResult * res,
+                           gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  GError * err = NULL;
+  GDBusProxy * proxy = g_dbus_proxy_new_for_bus_finish(res, &err);
+  if (!proxy)
+    {
+      if (err && !g_error_matches(err, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning("PowerSaver: proxy create failed: %s", err->message);
+      g_clear_error(&err);
+      g_object_unref(self);
+      return;
+    }
+
+  self->priv->proxy = proxy;
+  g_signal_connect(proxy, "g-signal", G_CALLBACK(on_proxy_signal), self);
+  refresh_all(self);
+  g_object_unref(self);
+}
+
+static void on_name_appeared(GDBusConnection * conn G_GNUC_UNUSED,
+                             const gchar * name G_GNUC_UNUSED,
+                             const gchar * owner G_GNUC_UNUSED,
+                             gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  if (!self->priv->service_available)
+    { self->priv->service_available = TRUE; emit_changed(self); }
+  if (!self->priv->proxy)
+    {
+      g_dbus_proxy_new_for_bus(
+        G_BUS_TYPE_SYSTEM,
+        G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+        NULL,
+        BUS_NAME, OBJECT_PATH, IFACE,
+        self->priv->cancellable,
+        on_proxy_ready,
+        g_object_ref(self));
+    }
+  else
+    {
+      refresh_all(self);
+    }
+}
+
+static void on_name_vanished(GDBusConnection * conn G_GNUC_UNUSED,
+                             const gchar * name G_GNUC_UNUSED,
+                             gpointer ud)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(ud);
+  g_clear_object(&self->priv->proxy);
+  if (self->priv->service_available)
+    { self->priv->service_available = FALSE; emit_changed(self); }
+}
+
+gboolean indicator_power_saver_service_available(IndicatorPowerSaver * self)
+{ return self->priv->service_available; }
+
+gboolean indicator_power_saver_is_available(IndicatorPowerSaver * self)
+{ return self->priv->available; }
+
+const gchar * indicator_power_saver_device_name(IndicatorPowerSaver * self)
+{ return self->priv->device_name ? self->priv->device_name : ""; }
+
+GStrv indicator_power_saver_profiles(IndicatorPowerSaver * self)
+{ return self->priv->profiles; }
+
+const gchar * indicator_power_saver_active_profile(IndicatorPowerSaver * self)
+{ return self->priv->active_profile ? self->priv->active_profile : ""; }
+
+gboolean indicator_power_saver_get_auto_on_battery(IndicatorPowerSaver * self)
+{ return self->priv->auto_on_battery; }
+
+void indicator_power_saver_set_active_profile(IndicatorPowerSaver * self,
+                                              const gchar * profile)
+{
+  if (!self->priv->proxy) return;
+  g_dbus_proxy_call(self->priv->proxy, "SetActiveProfile",
+                    g_variant_new("(s)", profile ? profile : ""),
+                    G_DBUS_CALL_FLAGS_NONE, -1,
+                    self->priv->cancellable, NULL, NULL);
+}
+
+void indicator_power_saver_set_auto_on_battery(IndicatorPowerSaver * self,
+                                               gboolean enabled)
+{
+  if (!self->priv->proxy) return;
+  g_dbus_proxy_call(self->priv->proxy, "SetAutoOnBattery",
+                    g_variant_new("(b)", enabled),
+                    G_DBUS_CALL_FLAGS_NONE, -1,
+                    self->priv->cancellable, NULL, NULL);
+}
+
+static void indicator_power_saver_init(IndicatorPowerSaver * self)
+{
+  self->priv = indicator_power_saver_get_instance_private(self);
+  self->priv->cancellable = g_cancellable_new();
+  self->priv->device_name = g_strdup("");
+  self->priv->active_profile = g_strdup("");
+
+  self->priv->watch_id = g_bus_watch_name(
+    G_BUS_TYPE_SYSTEM,
+    BUS_NAME,
+    G_BUS_NAME_WATCHER_FLAGS_AUTO_START,
+    on_name_appeared,
+    on_name_vanished,
+    self,
+    NULL);
+}
+
+static void indicator_power_saver_dispose(GObject * obj)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(obj);
+  if (self->priv->cancellable)
+    g_cancellable_cancel(self->priv->cancellable);
+  if (self->priv->watch_id)
+    { g_bus_unwatch_name(self->priv->watch_id); self->priv->watch_id = 0; }
+  g_clear_object(&self->priv->proxy);
+  g_clear_object(&self->priv->cancellable);
+  G_OBJECT_CLASS(indicator_power_saver_parent_class)->dispose(obj);
+}
+
+static void indicator_power_saver_finalize(GObject * obj)
+{
+  IndicatorPowerSaver * self = INDICATOR_POWER_SAVER(obj);
+  g_clear_pointer(&self->priv->device_name, g_free);
+  g_clear_pointer(&self->priv->active_profile, g_free);
+  g_clear_pointer(&self->priv->profiles, g_strfreev);
+  G_OBJECT_CLASS(indicator_power_saver_parent_class)->finalize(obj);
+}
+
+static void indicator_power_saver_class_init(IndicatorPowerSaverClass * klass)
+{
+  GObjectClass * oc = G_OBJECT_CLASS(klass);
+  oc->dispose = indicator_power_saver_dispose;
+  oc->finalize = indicator_power_saver_finalize;
+
+  signals[SIGNAL_CHANGED] =
+    g_signal_new("changed",
+                 G_TYPE_FROM_CLASS(klass),
+                 G_SIGNAL_RUN_LAST,
+                 0, NULL, NULL, NULL,
+                 G_TYPE_NONE, 0);
+}
+
+IndicatorPowerSaver * indicator_power_saver_new(void)
+{
+  return g_object_new(INDICATOR_TYPE_POWER_SAVER, NULL);
+}

--- a/src/power-saver.h
+++ b/src/power-saver.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2026 UBports Foundation.
+ * Copyright © 2026 Volla Systeme GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ */
+
+#ifndef INDICATOR_POWER_SAVER_H
+#define INDICATOR_POWER_SAVER_H
+
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define INDICATOR_TYPE_POWER_SAVER (indicator_power_saver_get_type())
+#define INDICATOR_POWER_SAVER(o)   (G_TYPE_CHECK_INSTANCE_CAST((o), INDICATOR_TYPE_POWER_SAVER, IndicatorPowerSaver))
+#define INDICATOR_IS_POWER_SAVER(o) (G_TYPE_CHECK_INSTANCE_TYPE((o), INDICATOR_TYPE_POWER_SAVER))
+
+typedef struct _IndicatorPowerSaver      IndicatorPowerSaver;
+typedef struct _IndicatorPowerSaverClass IndicatorPowerSaverClass;
+typedef struct _IndicatorPowerSaverPriv  IndicatorPowerSaverPriv;
+
+struct _IndicatorPowerSaver
+{
+  GObject parent;
+  IndicatorPowerSaverPriv * priv;
+};
+
+struct _IndicatorPowerSaverClass
+{
+  GObjectClass parent_class;
+};
+
+GType indicator_power_saver_get_type(void);
+
+IndicatorPowerSaver * indicator_power_saver_new(void);
+
+gboolean      indicator_power_saver_service_available(IndicatorPowerSaver * self);
+gboolean      indicator_power_saver_is_available(IndicatorPowerSaver * self);
+const gchar * indicator_power_saver_device_name(IndicatorPowerSaver * self);
+GStrv         indicator_power_saver_profiles(IndicatorPowerSaver * self);
+const gchar * indicator_power_saver_active_profile(IndicatorPowerSaver * self);
+gboolean      indicator_power_saver_get_auto_on_battery(IndicatorPowerSaver * self);
+
+void indicator_power_saver_set_active_profile(IndicatorPowerSaver * self, const gchar * profile);
+void indicator_power_saver_set_auto_on_battery(IndicatorPowerSaver * self, gboolean enabled);
+
+G_END_DECLS
+
+#endif /* INDICATOR_POWER_SAVER_H */

--- a/src/service.c
+++ b/src/service.c
@@ -32,6 +32,7 @@
 #include "device-provider.h"
 #include "keep-screen-on.h"
 #include "notifier.h"
+#include "power-saver.h"
 #include "service.h"
 #include "flashlight.h"
 #include "utils.h"
@@ -64,9 +65,10 @@ static GParamSpec * properties[LAST_PROP];
 
 enum
 {
-  SECTION_HEADER    = (1<<0),
-  SECTION_DEVICES   = (1<<1),
-  SECTION_SETTINGS  = (1<<2),
+  SECTION_HEADER     = (1<<0),
+  SECTION_DEVICES    = (1<<1),
+  SECTION_SETTINGS   = (1<<2),
+  SECTION_POWERSAVE  = (1<<3),
 };
 
 enum
@@ -109,6 +111,10 @@ struct _IndicatorPowerServicePrivate
   GSettings * settings;
 
   IndicatorPowerBrightness * brightness;
+  IndicatorPowerSaver * power_saver;
+  gulong power_saver_changed_id;
+  GSimpleAction * power_saver_profile_action;
+  GSimpleAction * power_saver_auto_action;
 
   guint own_id;
   guint actions_export_id;
@@ -643,6 +649,44 @@ create_desktop_settings_section (IndicatorPowerService * self G_GNUC_UNUSED)
 }
 
 static GMenuModel *
+create_power_saver_section(IndicatorPowerService * self)
+{
+  GMenu * section = g_menu_new();
+  GMenuItem * item;
+
+  if (!indicator_power_saver_service_available(self->priv->power_saver) ||
+      !indicator_power_saver_is_available(self->priv->power_saver))
+    return G_MENU_MODEL(section);
+
+  item = g_menu_item_new(_("Default (stock)"), NULL);
+  g_menu_item_set_action_and_target(item, "indicator.power-saver-profile",
+                                    "s", "");
+  g_menu_append_item(section, item);
+  g_object_unref(item);
+
+  GStrv profiles = indicator_power_saver_profiles(self->priv->power_saver);
+  if (profiles)
+    {
+      for (guint i = 0; profiles[i]; ++i)
+        {
+          item = g_menu_item_new(profiles[i], NULL);
+          g_menu_item_set_action_and_target(item, "indicator.power-saver-profile",
+                                            "s", profiles[i]);
+          g_menu_append_item(section, item);
+          g_object_unref(item);
+        }
+    }
+
+  item = g_menu_item_new(_("Engage on battery"), "indicator.power-saver-auto(true)");
+  g_menu_item_set_attribute(item, "x-ayatana-type", "s",
+                            "org.ayatana.indicator.switch");
+  g_menu_append_item(section, item);
+  g_object_unref(item);
+
+  return G_MENU_MODEL(section);
+}
+
+static GMenuModel *
 create_phone_settings_section(IndicatorPowerService * self)
 {
   GMenu * section;
@@ -742,6 +786,11 @@ rebuild_now (IndicatorPowerService * self, guint sections)
       rebuild_section (desktop->submenu, 1, create_desktop_settings_section (self));
       rebuild_section (phone->submenu, 1, create_phone_settings_section (self));
     }
+
+  if (sections & SECTION_POWERSAVE)
+    {
+      rebuild_section (phone->submenu, 2, create_power_saver_section (self));
+    }
 }
 
 static inline void
@@ -770,6 +819,7 @@ create_menu (IndicatorPowerService * self, int profile)
       case PROFILE_PHONE:
         sections[n++] = create_devices_section (self, PROFILE_PHONE);
         sections[n++] = create_phone_settings_section (self);
+        sections[n++] = create_power_saver_section (self);
         break;
 
       case PROFILE_DESKTOP:
@@ -853,6 +903,48 @@ on_phone_settings_activated (GSimpleAction * a      G_GNUC_UNUSED,
                              gpointer        gself  G_GNUC_UNUSED)
 {
     utils_handle_settings_request();
+}
+
+static void
+on_power_saver_profile_change_state (GSimpleAction * action,
+                                     GVariant      * value,
+                                     gpointer        gself)
+{
+  IndicatorPowerService * self = INDICATOR_POWER_SERVICE(gself);
+  const gchar * profile = g_variant_get_string(value, NULL);
+  indicator_power_saver_set_active_profile(self->priv->power_saver,
+                                           profile ? profile : "");
+  g_simple_action_set_state(action, value);
+}
+
+static void
+on_power_saver_auto_change_state (GSimpleAction * action,
+                                  GVariant      * value,
+                                  gpointer        gself)
+{
+  IndicatorPowerService * self = INDICATOR_POWER_SERVICE(gself);
+  gboolean enabled = g_variant_get_boolean(value);
+  indicator_power_saver_set_auto_on_battery(self->priv->power_saver, enabled);
+  g_simple_action_set_state(action, value);
+}
+
+static void
+on_power_saver_changed (IndicatorPowerSaver * saver G_GNUC_UNUSED,
+                        gpointer              gself)
+{
+  IndicatorPowerService * self = INDICATOR_POWER_SERVICE(gself);
+  priv_t * p = self->priv;
+  if (p->power_saver_profile_action)
+    g_simple_action_set_state(
+      p->power_saver_profile_action,
+      g_variant_new_string(
+        indicator_power_saver_active_profile(p->power_saver)));
+  if (p->power_saver_auto_action)
+    g_simple_action_set_state(
+      p->power_saver_auto_action,
+      g_variant_new_boolean(
+        indicator_power_saver_get_auto_on_battery(p->power_saver)));
+  rebuild_now(self, SECTION_POWERSAVE);
 }
 
 /***
@@ -947,6 +1039,31 @@ init_gactions (IndicatorPowerService * self)
   g_action_map_add_action (G_ACTION_MAP(p->actions), G_ACTION(a));
   g_signal_connect (a, "change-state", G_CALLBACK(on_brightness_change_requested), self);
   p->brightness_action = a;
+
+  /* add the power-saver actions */
+  {
+    pType = g_variant_type_new ("s");
+    a = g_simple_action_new_stateful (
+      "power-saver-profile", pType,
+      g_variant_new_string(
+        indicator_power_saver_active_profile(p->power_saver)));
+    g_variant_type_free(pType);
+    g_signal_connect(a, "change-state",
+                     G_CALLBACK(on_power_saver_profile_change_state), self);
+    g_action_map_add_action(G_ACTION_MAP(p->actions), G_ACTION(a));
+    p->power_saver_profile_action = a;
+
+    pType = g_variant_type_new ("b");
+    a = g_simple_action_new_stateful (
+      "power-saver-auto", pType,
+      g_variant_new_boolean(
+        indicator_power_saver_get_auto_on_battery(p->power_saver)));
+    g_variant_type_free(pType);
+    g_signal_connect(a, "change-state",
+                     G_CALLBACK(on_power_saver_auto_change_state), self);
+    g_action_map_add_action(G_ACTION_MAP(p->actions), G_ACTION(a));
+    p->power_saver_auto_action = a;
+  }
 
   /* add the show-time action */
   show_time_action = g_settings_create_action (p->settings, "show-time");
@@ -1186,6 +1303,14 @@ my_dispose (GObject * o)
   g_clear_object (&p->notifier);
   g_clear_object (&p->brightness_action);
   g_clear_object (&p->brightness);
+  if (p->power_saver_changed_id && p->power_saver)
+    {
+      g_signal_handler_disconnect(p->power_saver, p->power_saver_changed_id);
+      p->power_saver_changed_id = 0;
+    }
+  g_clear_object (&p->power_saver_profile_action);
+  g_clear_object (&p->power_saver_auto_action);
+  g_clear_object (&p->power_saver);
   g_clear_object (&p->battery_level_action);
   g_clear_object (&p->header_action);
   g_clear_object (&p->actions);
@@ -1228,6 +1353,11 @@ indicator_power_service_init (IndicatorPowerService * self)
   p->brightness = indicator_power_brightness_new();
   g_signal_connect_swapped(p->brightness, "notify::percentage",
                            G_CALLBACK(update_brightness_action_state), self);
+
+  p->power_saver = indicator_power_saver_new();
+  p->power_saver_changed_id =
+    g_signal_connect(p->power_saver, "changed",
+                     G_CALLBACK(on_power_saver_changed), self);
 
   init_gactions (self);
 


### PR DESCRIPTION
## Summary

Adds a power-saver section to the phone profile menu, driven by repowerd's `com.lomiri.Repowerd.PowerSaver` D-Bus service.

A new `IndicatorPowerSaver` proxy watches `com.lomiri.Repowerd.PowerSaver` on the system bus and refreshes its state on `ActiveProfileChanged` / `AutoOnBatteryChanged` signals. The phone profile gains a section containing:

- one radio item per per-device power profile exposed by the service,
- a **Default (stock)** entry that releases any active cap, and
- an **Engage on battery** switch.

The section stays empty when the service is not reachable, so the indicator degrades gracefully on platforms where repowerd's PowerSaver interface is absent.

## Details

- `src/power-saver.{c,h}` — new `IndicatorPowerSaver` GObject: watches the bus name, builds a proxy with `G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES`, mirrors `IsAvailable` / `GetDeviceName` / `ListProfiles` / `GetActiveProfile` / `GetAutoOnBattery`, emits a single `changed` signal, and exposes `SetActiveProfile` / `SetAutoOnBattery` setters.
- `src/service.c` — new `SECTION_POWERSAVE`, `create_power_saver_section()`, the `power-saver-profile` (stateful `s`) and `power-saver-auto` (stateful `b`) actions, change-state handlers, and the `changed` → rebuild wiring. The object is created in init and torn down in dispose.
- `src/CMakeLists.txt` — build the new source.

## Notes

This was originally carried as a downstream quilt patch in UBports packaging; it is moved here as a proper upstream source change. No `debian/changelog` entry is included so the maintainers can version it as they see fit.
