### PR TITLE
add an icon when "keep screen on" is active

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ if (ENABLE_DEVICEINFO)
     include_directories (${DEVICEINFO_INCLUDE_DIRS})
 endif ()
 
+## icons directory
+
+add_definitions(-DINDICATOR_ICONS_DIR="${CMAKE_INSTALL_FULL_DATADIR}/ayatana-indicator-power/icons")
+
 ##
 ##  custom targets
 ##

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -60,3 +60,8 @@ set (AYATANA_INDICATOR_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${AYATANA_INDICATOR_NAM
 
 install (FILES "${AYATANA_INDICATOR_FILE}"
          DESTINATION "${AYATANA_INDICATOR_DIR}")
+
+## Icon Files
+
+install (FILES "icons/keep-screen-on-symbolic.svg"
+        DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/ayatana-indicator-power/icons")

--- a/data/icons/keep-screen-on-symbolic.svg
+++ b/data/icons/keep-screen-on-symbolic.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="96"
+   height="96"
+   id="svg-lock-bar"
+   version="1.1"
+   viewBox="0 0 96 96">
+  <defs id="defs-lock-bar">
+    <!-- Knockout mask: white = visible. Black diagonal = transparent gap cut through the lock. -->
+    <mask id="bar-cut">
+      <rect x="0" y="0" width="96" height="96" fill="#ffffff" />
+      <rect x="43" y="-18" width="6" height="132" fill="#000000"
+            transform="rotate(45 48 48)" />
+    </mask>
+  </defs>
+  <g id="lock"
+     style="fill:#808080;fill-opacity:1;stroke:none"
+     mask="url(#bar-cut)">
+    <!-- Shackle (inverted U) -->
+    <path
+       id="shackle"
+       d="M 30.75,39.95 L 30.75,29.6 A 17.25,17.25 0 0 1 65.25,29.6 L 65.25,39.95 L 57.2,39.95 L 57.2,29.6 A 9.2,9.2 0 0 0 38.8,29.6 L 38.8,39.95 Z" />
+    <!-- Body -->
+    <rect id="body" x="22.7" y="38.8" width="50.6" height="46" rx="5.75" ry="5.75" />
+  </g>
+  <!-- Diagonal slash, same themeable color, sitting alongside the transparent gap -->
+  <rect
+     id="bar"
+     x="46" y="-8.5" width="4" height="113"
+     transform="rotate(45 48 48)"
+     style="fill:#808080;fill-opacity:1;stroke:none" />
+</svg>

--- a/src/service.c
+++ b/src/service.c
@@ -433,11 +433,25 @@ should_be_visible (IndicatorPowerService * self)
   return visible;
 }
 
+static gboolean
+is_keep_screen_on_active (const priv_t *p)
+{
+  GAction *kso = g_action_map_lookup_action (G_ACTION_MAP(p->actions), "keep-screen-on");
+  if (kso == NULL)
+    return FALSE;
+
+  GVariant *state = g_action_get_state (kso);
+  gboolean active = g_variant_get_boolean (state);
+  g_variant_unref (state);
+  return active;
+}
+
 static GVariant *
 create_header_state (IndicatorPowerService * self)
 {
   GVariantBuilder b;
   const priv_t * const p = self->priv;
+  const gboolean kso_active = is_keep_screen_on_active (p);
 
   g_variant_builder_init (&b, G_VARIANT_TYPE("a{sv}"));
 
@@ -448,6 +462,8 @@ create_header_state (IndicatorPowerService * self)
   g_variant_builder_add (&b, "{sv}", "visible",
                          g_variant_new_boolean (should_be_visible (self)));
 
+  GVariant *serialized_icons[2];
+  guint n_icons = 0;
   if (p->primary_device != NULL)
     {
       char * title;
@@ -476,31 +492,53 @@ create_header_state (IndicatorPowerService * self)
           else
             g_free (title);
         }
-
-      if ((icon = indicator_power_device_get_gicon (p->primary_device, TRUE, TRUE)))
-        {
-          GVariant * serialized_icon = g_icon_serialize (icon);
-
-          if (serialized_icon != NULL)
-            {
-              g_variant_builder_add (&b, "{sv}", "icon", serialized_icon);
-              g_variant_unref (serialized_icon);
-            }
-
-          g_object_unref (icon);
-        }
+        icon = indicator_power_device_get_gicon (p->primary_device, TRUE, TRUE);
+        if (icon != NULL)
+          {
+            GVariant *sv = g_icon_serialize (icon);
+            g_object_unref (icon);
+            if (sv != NULL)
+              serialized_icons[n_icons++] = sv;
+          }
     }
     else if (ayatana_common_utils_is_lomiri())
     {
         g_variant_builder_add (&b, "{sv}", "label", g_variant_new_string ("Fake battery"));
         g_variant_builder_add (&b, "{sv}", "accessible-desc", g_variant_new_string ("Fake battery"));
-        GIcon *pIcon = g_themed_icon_new_with_default_fallbacks ("battery-missing-symbolic");
-        GVariant *pIconSerialised = g_icon_serialize (pIcon);
-        g_object_unref (pIcon);
-        g_variant_builder_add (&b, "{sv}", "icon", pIconSerialised);
-        g_variant_unref (pIconSerialised);
-    }
 
+        GIcon *pIcon = g_themed_icon_new_with_default_fallbacks ("battery-missing-symbolic");
+        GVariant *sv = g_icon_serialize (pIcon);
+        g_object_unref (pIcon);
+        if (sv != NULL)
+          serialized_icons[n_icons++] = sv;
+    }
+  if (kso_active)
+    {
+      GFile *file = g_file_new_for_path(INDICATOR_ICONS_DIR "/keep-screen-on-symbolic.svg");
+      GIcon *kso_icon = g_file_icon_new(file);
+      g_object_unref(file);
+      GVariant *sv = g_icon_serialize (kso_icon);
+      g_object_unref (kso_icon);
+      if (sv != NULL)
+        serialized_icons[n_icons++] = sv;
+    }
+  if (n_icons == 1)
+    {
+      g_variant_builder_add (&b, "{sv}", "icon", serialized_icons[0]);
+      g_variant_unref (serialized_icons[0]);
+    }
+  else if (n_icons > 1)
+    {
+      GVariantBuilder icons_builder;
+      g_variant_builder_init (&icons_builder, G_VARIANT_TYPE ("av"));
+      for (guint i = 0; i < n_icons; i++)
+        {
+          g_variant_builder_add (&icons_builder, "v", serialized_icons[i]);
+          g_variant_unref (serialized_icons[i]);
+        }
+      GVariant *icons_variant = g_variant_builder_end (&icons_builder);
+      g_variant_builder_add (&b, "{sv}", "icons", icons_variant);
+    }
   return g_variant_builder_end (&b);
 }
 
@@ -941,6 +979,7 @@ init_gactions (IndicatorPowerService * self)
     g_variant_type_free (pType);
     g_action_map_add_action (G_ACTION_MAP(p->actions), G_ACTION(a));
     g_signal_connect(a, "change-state", G_CALLBACK(toggle_keep_screen_on_action), p->settings);
+    g_signal_connect_swapped(a, "notify::state", G_CALLBACK(rebuild_header_now), self);
   }
 
   /* add the flashlight action */


### PR DESCRIPTION
this is a follow up of the keep screen on PR.
it add an icon when the toggle is on so that the user don't forget about it.
The icon has been discussed a bit in the UX group.
don't know if it's the proper way of using an icon and if the path is correct, I'd be happy to apply changes.

<img width="1080" height="2220" alt="photo_5877585177926635091_w" src="https://github.com/user-attachments/assets/52f9de0f-79e8-4b0d-95f4-af6b97deccfb" />

<img width="1080" height="2220" alt="photo_5877585177926635092_w" src="https://github.com/user-attachments/assets/208da193-3ee2-41fd-873b-3a08a20b808b" />
